### PR TITLE
Cross-Platform Support

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -126,7 +126,7 @@ input[disabled].lr {
     opacity: 0.5;
 }
 
-input[type="text"]:focus {
+input[type="number"]:focus {
   outline: none;
 }
 
@@ -196,6 +196,7 @@ input[type="text"]:focus {
     font-variant: small-caps;
     display: flex;
     justify-content: flex-start;
+    flex-flow: row wrap;
 }
 
 #sun {
@@ -308,7 +309,7 @@ textarea:focus {
     color: #e60c88
 }
 
-#assessment > input[type="text"] {
+#assessment > input[type="number"] {
     margin-bottom: 12px;
     font-size: 20pt;
     width: 50px;
@@ -319,7 +320,7 @@ textarea:focus {
     border: 1px solid #ddd;
 }
 
-#assessment > input[type="text"]:focus {
+#assessment > input[type="number"]:focus {
     border: 1px solid #e60c88;
 }
 

--- a/index.html
+++ b/index.html
@@ -5,13 +5,12 @@
         <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/pills/1.0.1/pills.min.css"/>
         <link rel="stylesheet" type="text/css" href="css/index.css"/>
         <meta name="viewport" content="width=device-width,initial-scale=1">
+        <meta charset="utf-8"/>
     </head>
     <body>
         <div id="no_js">
             <a id="lr_logo" href="#"><img src="img/svg-white.svg" alt="Totality Logo"/></a>
-            You must have JavaScript enabled to use the TotalityHacks registration system.
-            <br/>
-            If you cannot use JavaScript, please contact <a href="mailto:hello@totalityhacks.com">hello@totalityhacks.com</a> for assistance.
+            You must have JavaScript enabled to use the TotalityHacks application reader system.
         </div>
 
         <iframe id="resumeViewer"></iframe>
@@ -37,9 +36,9 @@
                   <span id="resume" class="social"></span>
 
                   <div id="assessment">
-                      <input type="text" maxlength="1" id="skill" placeholder="#" autocomplete="off" required/> Skill (50%)<br />
-                      <input type="text" maxlength="1" id="community" placeholder="#" autocomplete="off" required/> Community (25%)<br />
-                      <input type="text" maxlength="1" id="passion" placeholder="#" autocomplete="off" required/> Passion (25%)<br />
+                      <input type="number" min="0" max="5" id="skill" placeholder="#" autocomplete="off" required/> Skill (50%)<br />
+                      <input type="number" min="0" max="5" id="community" placeholder="#" autocomplete="off" required/> Community (25%)<br />
+                      <input type="number" min="0" max="5" id="passion" placeholder="#" autocomplete="off" required/> Passion (25%)<br />
                   </div>
 
                   <button id="submit" class="btn">


### PR DESCRIPTION
minor tweaks to make the app reader better support non-macOS platforms:
- specify the charset rather than using the default
- set the type of the number input to be "number", so the appropriate software keyboard shows up on mobile platforms
- make the header more responsive (so it wraps on narrow screens)

other:
- change the JavaScript disabled error message to correctly say that this is the app reader, not the registration system